### PR TITLE
Buffer management

### DIFF
--- a/pkg/runtime/protocol.go
+++ b/pkg/runtime/protocol.go
@@ -79,6 +79,7 @@ const (
 	BufferSize = 1024 * 1024
 	// min packet length
 	MinPacketLength = 12
+	HeaderSize      = 4 + 4 + 4
 
 	// \x00REQ
 	Req    = 5391697


### PR DESCRIPTION
This still maintains a double-copy which is less than ideal, but is
significantly faster as a result because the target region which holds
the `data` parameter to the response is now dynamically allocated so as
to avoid unnecessary copies and dynamic/exponential allocation.

Further cleaned-up the parsing of the response and removed the
`decodeResponse` function which had lots of funky logic around wierd
buffer management.

Abstracted the reconnect behavior out into a separate method so it can
be reused whether the header or buffer are being read.