### PR TITLE
client: gearman client now faster and better

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,6 +21,7 @@ import (
 var (
 	DefaultTimeout time.Duration = time.Second
 	Null                         = byte('\x00')
+	NullBytes                    = []byte{Null}
 )
 
 // One client connect to one server.
@@ -28,14 +29,17 @@ var (
 type Client struct {
 	sync.Mutex
 
-	net, addr    string
-	respHandler  *responseHandlerMap
-	innerHandler *responseHandlerMap
-	in           chan *Response
-	conn         net.Conn
-	rw           *bufio.ReadWriter
+	net, addr string
+	handlers  sync.Map
+	expected  chan *Response
+	outbound  chan *request
+	conn      net.Conn
+	rw        *bufio.ReadWriter
 
-	ResponseTimeout time.Duration // response timeout for do()
+	responsePool *sync.Pool
+	requestPool  *sync.Pool
+
+	ResponseTimeout time.Duration
 
 	ErrorHandler ErrorHandler
 }
@@ -72,48 +76,67 @@ func New(network, addr string) (client *Client, err error) {
 	client = &Client{
 		net:             network,
 		addr:            addr,
-		respHandler:     newResponseHandlerMap(),
-		innerHandler:    newResponseHandlerMap(),
-		in:              make(chan *Response, rt.QueueSize),
+		outbound:        make(chan *request),
+		expected:        make(chan *Response),
 		ResponseTimeout: DefaultTimeout,
+		responsePool:    &sync.Pool{New: func() interface{} { return &Response{} }},
+		requestPool:     &sync.Pool{New: func() interface{} { return &request{} }},
 	}
+
 	client.conn, err = net.Dial(client.net, client.addr)
+
 	if err != nil {
 		return
 	}
+
 	client.rw = bufio.NewReadWriter(bufio.NewReader(client.conn),
 		bufio.NewWriter(client.conn))
+
 	go client.readLoop()
-	go client.processLoop()
+	go client.writeLoop()
+
 	return
 }
 
-func (client *Client) write(req *request) (err error) {
-	var n int
-	buf := req.Encode()
-	for i := 0; i < len(buf); i += n {
-		n, err = client.rw.Write(buf[i:])
-		if err != nil {
-			return
-		}
-	}
-	return client.rw.Flush()
-}
+func (client *Client) writeLoop() {
+	ibuf := make([]byte, 4)
+	length := uint32(0)
+	var i int
 
-func (client *Client) read(length int) (data []byte, err error) {
-	n := 0
-	buf := rt.NewBuffer(rt.BufferSize)
-	// read until data can be unpacked
-	for i := length; i > 0 || len(data) < rt.MinPacketLength; i -= n {
-		if n, err = client.rw.Read(buf); err != nil {
-			return
+	// Pipeline requests; but only write them one at a time. To allow multiple
+	// goroutines to all write as quickly as possible, uses a channel and the
+	// writeLoop lives in a separate goroutine.
+	for req := range client.outbound {
+		client.rw.Write([]byte(rt.ReqStr))
+
+		binary.BigEndian.PutUint32(ibuf, req.pt.Uint32())
+
+		client.rw.Write(ibuf)
+
+		length = 0
+
+		for _, chunk := range req.data {
+			length += uint32(len(chunk))
 		}
-		data = append(data, buf[0:n]...)
-		if n < rt.BufferSize {
-			break
+
+		// nil separators
+		length += uint32(len(req.data)) - 1
+
+		binary.BigEndian.PutUint32(ibuf, length)
+
+		client.rw.Write(ibuf)
+
+		client.rw.Write(req.data[0])
+
+		for i = 1; i < len(req.data); i++ {
+			client.rw.Write(NullBytes)
+			client.rw.Write(req.data[i])
 		}
+
+		client.requestPool.Put(req)
+
+		client.rw.Flush()
 	}
-	return
 }
 
 func decodeHeader(header []byte) (code []byte, pt uint32, length int) {
@@ -125,6 +148,10 @@ func decodeHeader(header []byte) (code []byte, pt uint32, length int) {
 }
 
 func (client *Client) reconnect(err error) error {
+	if client.conn != nil {
+		return nil
+	}
+
 	// TODO I doubt this error handling is right because it looks
 	// really complicated.
 	if opErr, ok := err.(*net.OpError); ok {
@@ -160,8 +187,6 @@ func (client *Client) reconnect(err error) error {
 }
 
 func (client *Client) readLoop() {
-	defer close(client.in)
-
 	header := make([]byte, rt.HeaderSize)
 
 	var err error
@@ -188,9 +213,10 @@ func (client *Client) readLoop() {
 			continue
 		}
 
-		resp = getResponse()
+		resp = client.responsePool.Get().(*Response)
 
 		resp.DataType, err = rt.NewPT(pt)
+
 		if err != nil {
 			client.err(err)
 			continue
@@ -218,28 +244,36 @@ func (client *Client) readLoop() {
 			resp.Data = contents
 		}
 
-		client.in <- resp
+		client.process(resp)
 	}
 }
 
-func (client *Client) processLoop() {
-	for resp := range client.in {
-		switch resp.DataType {
-		case rt.PT_Error:
-			log.Errorln("Received error", resp.Data)
-			client.err(getError(resp.Data))
-		case rt.PT_StatusRes:
-			resp = client.handleInner("s"+resp.Handle, resp)
-		case rt.PT_JobCreated:
-			resp = client.handleInner("c", resp)
-		case rt.PT_EchoRes:
-			resp = client.handleInner("e", resp)
-		case rt.PT_WorkData, rt.PT_WorkWarning, rt.PT_WorkStatus:
-			resp = client.handleResponse(resp.Handle, resp)
-		case rt.PT_WorkComplete, rt.PT_WorkFail, rt.PT_WorkException:
-			client.handleResponse(resp.Handle, resp)
-			client.respHandler.remove(resp.Handle)
+func (client *Client) process(resp *Response) {
+	switch resp.DataType {
+	case rt.PT_Error:
+		log.Errorln("Received error", resp.Data)
+
+		client.err(getError(resp.Data))
+
+		client.responsePool.Put(resp)
+
+	case rt.PT_StatusRes, rt.PT_JobCreated, rt.PT_EchoRes:
+		// NOTE Anything which reads from `expected` must return the
+		// response object to the pool.
+		client.expected <- resp
+	case rt.PT_WorkComplete, rt.PT_WorkFail, rt.PT_WorkException:
+		defer client.handlers.Delete(resp.Handle)
+		fallthrough
+	case rt.PT_WorkData, rt.PT_WorkWarning, rt.PT_WorkStatus:
+		// These alternate conditions should not happen so long as
+		// everyone is following the specification.
+		if handler, ok := client.handlers.Load(resp.Handle); ok {
+			if h, ok := handler.(ResponseHandler); ok {
+				h(resp)
+			}
 		}
+
+		client.responsePool.Put(resp)
 	}
 }
 
@@ -249,95 +283,62 @@ func (client *Client) err(e error) {
 	}
 }
 
-func (client *Client) handleResponse(key string, resp *Response) *Response {
-	if h, ok := client.respHandler.get(key); ok {
-		h(resp)
-		return nil
-	}
-	return resp
-}
-
-func (client *Client) handleInner(key string, resp *Response) *Response {
-	if h, ok := client.innerHandler.get(key); ok {
-		h(resp)
-		client.innerHandler.remove(key)
-		return nil
-	}
-	return resp
-}
-
 type handleOrError struct {
 	handle string
 	err    error
 }
 
-func (client *Client) do(funcname string, data []byte, flag rt.PT) (handle string, err error) {
-	if client.conn == nil {
-		return "", ErrLostConn
-	}
-	var result = make(chan handleOrError, 1)
-	client.Lock()
-	defer client.Unlock()
-	client.innerHandler.put("c", func(resp *Response) {
-		if resp.DataType == rt.PT_Error {
-			err = getError(resp.Data)
-			result <- handleOrError{"", err}
-			return
-		}
-		handle = resp.Handle
-		result <- handleOrError{handle, nil}
-	})
-	id := IdGen.Id()
-	req := getJob(id, []byte(funcname), data)
-	req.DataType = flag
-	if err = client.write(req); err != nil {
-		client.innerHandler.remove("c")
-		return
-	}
-	var timer = time.After(client.ResponseTimeout)
-	select {
-	case ret := <-result:
-		return ret.handle, ret.err
-	case <-timer:
-		client.innerHandler.remove("c")
-		return "", ErrLostConn
-	}
-	return
+func (client *Client) request() *request {
+	return client.requestPool.Get().(*request)
+}
+
+func (client *Client) submit(pt rt.PT, funcname string, arg []byte) string {
+	client.outbound <- client.request().submitJob(pt, funcname, IdGen.Id(), arg)
+
+	res := <-client.expected
+
+	client.responsePool.Put(res)
+
+	return res.Handle
 }
 
 // Call the function and get a response.
 // flag can be set to: JobLow, JobNormal and JobHigh
-func (client *Client) Do(funcname string, data []byte,
+func (client *Client) Do(funcname string, arg []byte,
 	flag byte, h ResponseHandler) (handle string, err error) {
-	var datatype rt.PT
+	var pt rt.PT
+
 	switch flag {
 	case rt.JobLow:
-		datatype = rt.PT_SubmitJobLow
+		pt = rt.PT_SubmitJobLow
 	case rt.JobHigh:
-		datatype = rt.PT_SubmitJobHigh
+		pt = rt.PT_SubmitJobHigh
 	default:
-		datatype = rt.PT_SubmitJob
+		pt = rt.PT_SubmitJob
 	}
-	handle, err = client.do(funcname, data, datatype)
-	if err == nil && h != nil {
-		client.respHandler.put(handle, h)
-	}
+
+	handle = client.submit(pt, funcname, arg)
+
+	client.handlers.Store(handle, h)
+
 	return
 }
 
 // Call the function in background, no response needed.
 // flag can be set to: JobLow, JobNormal and JobHigh
-func (client *Client) DoBg(funcname string, data []byte, flag byte) (handle string, err error) {
-	var datatype rt.PT
+func (client *Client) DoBg(funcname string, arg []byte, flag byte) (handle string, err error) {
+	var pt rt.PT
 	switch flag {
 	case rt.JobLow:
-		datatype = rt.PT_SubmitJobLowBG
+		pt = rt.PT_SubmitJobLowBG
 	case rt.JobHigh:
-		datatype = rt.PT_SubmitJobHighBG
+		pt = rt.PT_SubmitJobHighBG
 	default:
-		datatype = rt.PT_SubmitJobBG
+		pt = rt.PT_SubmitJobBG
 	}
-	handle, err = client.do(funcname, data, datatype)
+
+	handle = client.submit(pt, funcname, arg)
+
 	return
 }
 
@@ -369,7 +370,9 @@ func (client *Client) doCron(funcname string, cronExpr string, funcParam []byte)
 		return "", err
 	}
 	dbyt := []byte(fmt.Sprintf("%v%v", string(ce.Bytes()), string(funcParam)))
-	handle, err = client.do(funcname, dbyt, rt.PT_SubmitJobSched)
+
+	handle = client.submit(rt.PT_SubmitJobSched, funcname, dbyt)
+
 	return
 }
 
@@ -377,50 +380,45 @@ func (client *Client) DoAt(funcname string, epoch int64, funcParam []byte) (hand
 	if client.conn == nil {
 		return "", ErrLostConn
 	}
+
 	dbyt := []byte(fmt.Sprintf("%v\x00%v", epoch, string(funcParam)))
-	handle, err = client.do(funcname, dbyt, rt.PT_SubmitJobEpoch)
+
+	handle = client.submit(rt.PT_SubmitJobEpoch, funcname, dbyt)
+
 	return
 }
 
 // Get job status from job server.
 func (client *Client) Status(handle string) (status *Status, err error) {
-	if client.conn == nil {
-		return nil, ErrLostConn
+	if err = client.reconnect(nil); err != nil {
+		return
 	}
-	var mutex sync.Mutex
-	mutex.Lock()
-	client.innerHandler.put("s"+handle, func(resp *Response) {
-		defer mutex.Unlock()
-		var err error
-		status, err = resp._status()
-		if err != nil {
-			client.err(err)
-		}
-	})
-	req := getRequest()
-	req.DataType = rt.PT_GetStatus
-	req.Data = []byte(handle)
-	client.write(req)
-	mutex.Lock()
+
+	client.outbound <- client.request().status(handle)
+
+	res := <-client.expected
+
+	status, err = res.Status()
+
+	client.responsePool.Put(res)
+
 	return
 }
 
 // Echo.
 func (client *Client) Echo(data []byte) (echo []byte, err error) {
-	if client.conn == nil {
-		return nil, ErrLostConn
+	if err = client.reconnect(nil); err != nil {
+		return
 	}
-	var mutex sync.Mutex
-	mutex.Lock()
-	client.innerHandler.put("e", func(resp *Response) {
-		echo = resp.Data
-		mutex.Unlock()
-	})
-	req := getRequest()
-	req.DataType = rt.PT_EchoReq
-	req.Data = data
-	client.write(req)
-	mutex.Lock()
+
+	client.outbound <- client.request().echo(data)
+
+	res := <-client.expected
+
+	echo = res.Data
+
+	client.responsePool.Put(res)
+
 	return
 }
 

--- a/client/request.go
+++ b/client/request.go
@@ -1,44 +1,40 @@
 package client
 
 import (
-	"encoding/binary"
-
 	rt "github.com/ssmccoy/g2/pkg/runtime"
 )
 
 // Request from client
 type request struct {
-	DataType rt.PT
-	Data     []byte
+	pt   rt.PT
+	data [][]byte
 }
 
-// Encode a Request to byte slice
-func (req *request) Encode() (data []byte) {
-	l := len(req.Data)           // length of data
-	tl := l + rt.MinPacketLength // add 12 bytes head
-	data = rt.NewBuffer(tl)
-	copy(data[:4], rt.ReqStr)
-	binary.BigEndian.PutUint32(data[4:8], req.DataType.Uint32())
-	binary.BigEndian.PutUint32(data[8:12], uint32(l))
-	copy(data[rt.MinPacketLength:], req.Data)
-	return
+func (req *request) args(args ...[]byte) {
+	req.data = req.data[:0]
+	req.data = append(req.data, args...)
 }
 
-func getRequest() (req *request) {
-	// TODO add a pool
-	req = &request{}
-	return
+func (req *request) submitJob(pt rt.PT, funcname, id string, arg []byte) *request {
+	req.pt = pt
+
+	req.args([]byte(funcname), []byte(id), arg)
+
+	return req
 }
 
-func getJob(id string, funcname, data []byte) (req *request) {
-	req = getRequest()
-	a := len(funcname)
-	b := len(id)
-	c := len(data)
-	l := a + b + c + 2
-	req.Data = rt.NewBuffer(l)
-	copy(req.Data[0:a], funcname)
-	copy(req.Data[a+1:a+b+1], []byte(id))
-	copy(req.Data[a+b+2:], data)
-	return
+func (req *request) status(handle string) *request {
+	req.pt = rt.PT_GetStatus
+
+	req.args([]byte(handle))
+
+	return req
+}
+
+func (req *request) echo(arg []byte) *request {
+	req.pt = rt.PT_EchoReq
+
+	req.args(arg)
+
+	return req
 }

--- a/client/response.go
+++ b/client/response.go
@@ -16,6 +16,7 @@ type Response struct {
 	DataType  rt.PT
 	Data, UID []byte
 	Handle    string
+	err       error
 }
 
 // Extract the Response's result.

--- a/go.mod
+++ b/go.mod
@@ -3,22 +3,27 @@ module github.com/ssmccoy/g2
 require (
 	github.com/appscode/go v0.0.0-20180628092646-df3c57fca2be
 	github.com/appscode/pat v0.0.0-20170521084856-48ff78925b79
-	github.com/beorn7/perks v0.0.0-20160229213445-3ac7bf7a47d1
-	github.com/golang/glog v0.0.0-20141105023935-44145f04b68c
-	github.com/golang/protobuf v1.1.0
-	github.com/golang/snappy v0.0.0-20160529050041-d9eb7a3d35ec
-	github.com/google/uuid v0.0.0-20171113160352-8c31c18f31ed
-	github.com/inconshreveable/mousetrap v1.0.0
-	github.com/matttproud/golang_protobuf_extensions v0.0.0-20150406173934-fc2b8d3a73c4
+	github.com/beorn7/perks v0.0.0-20160229213445-3ac7bf7a47d1 // indirect
+	github.com/golang/glog v0.0.0-20141105023935-44145f04b68c // indirect
+	github.com/golang/snappy v0.0.0-20160529050041-d9eb7a3d35ec // indirect
+	github.com/google/uuid v0.0.0-20171113160352-8c31c18f31ed // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/kr/pretty v0.1.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v0.0.0-20150406173934-fc2b8d3a73c4 // indirect
 	github.com/mikespook/golib v0.0.0-20151119134446-38fe6917d34b
+	github.com/onsi/ginkgo v1.7.0 // indirect
+	github.com/onsi/gomega v1.4.3 // indirect
 	github.com/prometheus/client_golang v0.8.0
-	github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335
-	github.com/prometheus/common v0.0.0-20170427095455-13ba4ddd0caa
-	github.com/prometheus/procfs v0.0.0-20170519190837-65c1f6f8f0fc
+	github.com/prometheus/client_model v0.0.0-20150212101744-fa8ad6fec335 // indirect
+	github.com/prometheus/common v0.0.0-20170427095455-13ba4ddd0caa // indirect
+	github.com/prometheus/procfs v0.0.0-20170519190837-65c1f6f8f0fc // indirect
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/pflag v1.0.1
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d
-	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce
+	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
+	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
+	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )


### PR DESCRIPTION
Eliminated the strange usage of in favor of using channels. Removed the
redundant `processLoop` goroutine, the `readLoop` now inlines the
processing (it was serial anyway!). Switched to the use of threadsafe
memory object pools for request and response objects, and now allows
pipelining if multiple goroutines are making requests at once.

Removed a lot of redundancy in the code, and eliminated the use of the
strange `responseHandlerMap` in favor of a concurrent map for holding
callbacks on a per-handler basis.

Refactored the `request` type such that it now uses a builder pattern,
and now itself keeps a small byte buffer for each request which is
reused when parameters are attached to requests. Streamlined the
formatting of outbound messages such that they are encoded as they are
written to the output buffer, to reduce the number of copies involved in
most operations.

Eliminated the strange blind-read loop which pretended it had no idea
how large of a buffer it would need to allocate to read a response, and
now allocates a buffer for each payload, the size of the payload as
specified by the server, respectively.