### PR TITLE
Fix send/receive synchronization race condition

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -430,7 +430,7 @@ func (client *Client) readLoop() {
 		client.process(req, resp)
 
 		// recycle the request object, it's 2nd life has ended
-		req.close()
+		//req.close()
 		client.requestPool.Put(req)
 	}
 
@@ -498,8 +498,10 @@ func (client *Client) submit(reqType rt.PT, funcname string, payload []byte) (ha
 
 	chans := client.loadChans()
 	req := client.request().submitJob(reqType, funcname, IdGen.Id(), payload)
+	client.Log(Debug, "writing to chans.outbound...")
 	chans.outbound <- req
 
+	client.Log(Debug, "reading from req.expected...")
 	if res := <-req.expected; res != nil {
 		var err error
 		if res.DataType == rt.PT_Error {

--- a/client/client.go
+++ b/client/client.go
@@ -332,18 +332,13 @@ func (client *Client) reconnect(err error) error {
 
 func (client *Client) drainInProgress() {
 	defer func() {
-		if e := safeCastError(recover(), "panic in submit()"); e != nil {
-			client.Log(Debug, fmt.Sprintf("drainInProgress recover: %s", e))
-		}
+		recover()
 	}()
 
-	var count int32
 	for req := range client.chans.inProgress {
 		req.close()
 		client.requestPool.Put(req) // recycle here since it didn't get to be processed
-		count++
 	}
-	client.Log(Debug, fmt.Sprintf("drain inProgress removed %d entries", count))
 
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -191,7 +191,7 @@ func (client *Client) IsConnectionSet() bool {
 func (client *Client) writeReconnectCleanup(conn *connection, req *request, ibufs ...[]byte) bool {
 	for _, ibuf := range ibufs {
 		if _, err := conn.Write(ibuf); err != nil {
-			//client.requestPool.Put(req)
+			client.requestPool.Put(req)
 			go client.reconnect(err)
 			return true // return true will cause writeLoop to exit, it will be restarted upon successful reconnect
 		}

--- a/client/client.go
+++ b/client/client.go
@@ -493,7 +493,7 @@ func (client *Client) submit(reqType rt.PT, funcname string, payload []byte) (ha
 	}()
 
 	chans := client.loadChans()
-	req := client.request().submit(reqType, funcname, IdGen.Id(), payload)
+	req := client.request().submitJob(reqType, funcname, IdGen.Id(), payload)
 	chans.outbound <- req
 
 	if res := <-req.expected; res != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -497,10 +497,8 @@ func (client *Client) submit(reqType rt.PT, funcname string, payload []byte) (ha
 
 	chans := client.loadChans()
 	req := client.request().submitJob(reqType, funcname, IdGen.Id(), payload)
-	client.Log(Debug, "writing to chans.outbound...")
 	chans.outbound <- req
 
-	client.Log(Debug, "reading from req.expected...")
 	if res := <-req.expected; res != nil {
 		var err error
 		if res.DataType == rt.PT_Error {

--- a/client/client.go
+++ b/client/client.go
@@ -64,6 +64,7 @@ type Client struct {
 	connCloseHandler ConnCloseHandler
 	connOpenHandler  ConnOpenHandler
 	logHandler       LogHandler
+	submitLock       sync.Mutex
 }
 
 type LogLevel int
@@ -464,6 +465,9 @@ func (client *Client) request() *request {
 }
 
 func (client *Client) submit(pt rt.PT, funcname string, payload []byte) (handle string, err error) {
+
+	client.submitLock.Lock()
+	defer client.submitLock.Unlock()
 
 	defer func() {
 		if e := safeCastError(recover(), "panic in submit()"); e != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -65,7 +65,6 @@ type Client struct {
 	connCloseHandler ConnCloseHandler
 	connOpenHandler  ConnOpenHandler
 	logHandler       LogHandler
-	submitLock       sync.Mutex
 }
 
 type LogLevel int
@@ -485,9 +484,6 @@ func (client *Client) request() *request {
 }
 
 func (client *Client) submit(reqType rt.PT, funcname string, payload []byte) (handle string, err error) {
-
-	client.submitLock.Lock()
-	defer client.submitLock.Unlock()
 
 	defer func() {
 		if e := safeCastError(recover(), "panic in submit()"); e != nil {

--- a/client/request.go
+++ b/client/request.go
@@ -23,7 +23,7 @@ func (req *request) args(args ...[]byte) {
 	req.expected = make(chan *Response, 1)
 }
 
-func (req *request) submit(reqType rt.PT, funcname, id string, arg []byte) *request {
+func (req *request) submitJob(reqType rt.PT, funcname, id string, arg []byte) *request {
 	req.pt = reqType
 
 	req.args([]byte(funcname), []byte(id), arg)

--- a/client/request.go
+++ b/client/request.go
@@ -6,17 +6,25 @@ import (
 
 // Request from client
 type request struct {
-	pt   rt.PT
-	data [][]byte
+	pt       rt.PT
+	expected chan *Response
+	data     [][]byte
+}
+
+func (req *request) close() {
+	if req.expected != nil {
+		close(req.expected)
+	}
 }
 
 func (req *request) args(args ...[]byte) {
 	req.data = req.data[:0]
 	req.data = append(req.data, args...)
+	req.expected = make(chan *Response, 1)
 }
 
-func (req *request) submitJob(pt rt.PT, funcname, id string, arg []byte) *request {
-	req.pt = pt
+func (req *request) submit(reqType rt.PT, funcname, id string, arg []byte) *request {
+	req.pt = reqType
 
 	req.args([]byte(funcname), []byte(id), arg)
 


### PR DESCRIPTION
Fix synchronization race condition between outbound and expected channels to avoid mix up of the request and response matching. 