### PR TITLE
fix receive race

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -442,7 +442,7 @@ func (client *Client) process(resp *Response) {
 		req := <-client.loadChans().inProgress
 		// recycle the request object, it's 2nd life has ended
 		req.expected <- resp
-		req.close()
+		//req.close()
 		client.requestPool.Put(req)
 	case rt.PT_WorkComplete, rt.PT_WorkFail, rt.PT_WorkException:
 		defer client.handlers.Delete(resp.Handle)

--- a/client/client.go
+++ b/client/client.go
@@ -218,7 +218,6 @@ func (client *Client) writeLoop() {
 		if conn == nil {
 			req.close()
 			client.requestPool.Put(req)
-			client.Log(Debug, fmt.Sprintf("closing req channel because connections are null"))
 			return
 		}
 
@@ -333,18 +332,13 @@ func (client *Client) reconnect(err error) error {
 
 func (client *Client) drainInProgress() {
 	defer func() {
-		if e := safeCastError(recover(), "panic in submit()"); e != nil {
-			client.Log(Debug, fmt.Sprintf("drainInProgress recover: %s", e))
-		}
+		recover()
 	}()
 
-	var count int32
 	for req := range client.chans.inProgress {
 		req.close()
 		client.requestPool.Put(req) // recycle here since it didn't get to be processed
-		count++
 	}
-	client.Log(Debug, fmt.Sprintf("drain inProgress removed %d entries", count))
 }
 
 func (client *Client) loadConn() *connection {


### PR DESCRIPTION
Waiter's request and inbound channels were closed sometimes before the waiter was able to retrieve its respective messages.

As a solution I moved the close/recycle ops into the waiters' areas so that they close/recycle when they are done.