### PR TITLE
Sync/Wait for processing handler

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -25,7 +25,7 @@ var (
 )
 
 const (
-	WorkHandleDelay     = 5 // milliseconds delay for re-try processing of work completion requests if handler hasn't been yet stored in hash map.
+	WorkHandleDelay     = 500 // milliseconds delay for re-try processing of work completion requests if handler hasn't been yet stored in hash map.
 	InProgressQueueSize = 8
 )
 

--- a/client/client.go
+++ b/client/client.go
@@ -25,9 +25,8 @@ var (
 )
 
 const (
-	WorkHandleDelay      = 1 // milliseconds delay for re-try processing of work completion requests if handler hasn't been yet stored in hash map.
-	WorkHandleDelayTries = 500
-	InProgressQueueSize  = 8
+	WorkHandleTimeoutMs = 500 // milliseconds delay for re-try processing of work completion requests if handler hasn't been yet stored in hash map.
+	InProgressQueueSize = 8
 )
 
 type connection struct {
@@ -446,7 +445,7 @@ func (client *Client) process(resp *Response) {
 		// everyone is following the specification.
 		var handler interface{}
 		var ok = false
-		if handler, ok = client.handlers.Get(resp.Handle, WorkHandleDelay*WorkHandleDelayTries); !ok {
+		if handler, ok = client.handlers.Get(resp.Handle, WorkHandleTimeoutMs); !ok {
 			client.err(errors.New(fmt.Sprintf("unexpected %s response for \"%s\" with no handler", resp.DataType, resp.Handle)))
 		} else {
 			if h, ok := handler.(ResponseHandler); ok {

--- a/client/client.go
+++ b/client/client.go
@@ -25,8 +25,8 @@ var (
 )
 
 const (
-	WorkHandleDelay      = 5 // milliseconds delay for re-try processing of work completion requests if handler hasn't been yet stored in hash map.
-	WorkHandleDelayTries = 100
+	WorkHandleDelay      = 1 // milliseconds delay for re-try processing of work completion requests if handler hasn't been yet stored in hash map.
+	WorkHandleDelayTries = 500
 	InProgressQueueSize  = 8
 )
 

--- a/client/handler_map.go
+++ b/client/handler_map.go
@@ -25,6 +25,12 @@ func NewHandlerMap() *HandlerMap {
 	}
 }
 
+func (m *HandlerMap) GetCounts() (counts int, waiters int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.innerMap), len(m.waitersMap)
+}
+
 func (m *HandlerMap) Put(key string, value ResponseHandler) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/client/handler_map.go
+++ b/client/handler_map.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"container/list"
+	"golang.org/x/net/context"
+
+	"sync"
+	"time"
+)
+
+type HandlerMap struct {
+	mu       sync.Mutex
+	innerMap map[string]ResponseHandler
+	waiters  list.List
+}
+
+type waiter struct {
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+func NewHandlerMap() *HandlerMap {
+	return &HandlerMap{sync.Mutex{},
+		make(map[string]ResponseHandler, 100),
+		list.List{},
+	}
+}
+
+func (m *HandlerMap) Put(key string, value ResponseHandler) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.innerMap[key] = value
+	// signal to any waiters here
+	for {
+		next := m.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+		w := next.Value.(waiter)
+		m.waiters.Remove(next)
+		close(w.ready)
+	}
+}
+
+func (m *HandlerMap) Delete(key string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.innerMap, key)
+}
+
+func (m *HandlerMap) Get(key string, timeoutMs int) (value ResponseHandler, ok bool) {
+	m.mu.Lock()
+
+	// optimistic check first
+	value, ok = m.innerMap[key]
+	if ok {
+		m.mu.Unlock()
+		return
+	}
+
+	// let's remember the current time
+	curTime := time.Now()
+	maxTime := curTime.Add(time.Duration(timeoutMs) * time.Millisecond)
+
+	for time.Now().Before(maxTime) && !ok {
+		value, ok = m.innerMap[key]
+		if !ok {
+			nsLeft := maxTime.Sub(time.Now()).Nanoseconds()
+			ctx, _ := context.WithTimeout(context.Background(), time.Duration(nsLeft)*time.Nanosecond)
+
+			ready := make(chan struct{})
+			w := waiter{ready: ready}
+			elem := m.waiters.PushBack(w)
+			m.mu.Unlock() // unlock before we start waiting on stuff
+
+			select {
+			case <-ctx.Done():
+				m.mu.Lock()
+				select {
+				case <-ready:
+					// in case we got signalled during cancellation
+					continue
+				default:
+					// we got timeout, let's remove
+					m.waiters.Remove(elem)
+				}
+				m.mu.Unlock()
+				return
+
+			case <-ready:
+				m.mu.Lock() // going back to the loop, gotta lock
+				continue
+			}
+		}
+	}
+
+	m.mu.Unlock()
+	return
+}

--- a/client/handler_map.go
+++ b/client/handler_map.go
@@ -96,6 +96,9 @@ func (m *HandlerMap) Get(key string, timeoutMs int) (value ResponseHandler, ok b
 				default:
 					// we got timeout, let's remove
 					waiters.Remove(elem)
+					if waiters.Len() == 0 {
+						delete(m.waitersMap, key)
+					}
 				}
 				m.mu.Unlock()
 				return

--- a/client/handler_map.go
+++ b/client/handler_map.go
@@ -37,6 +37,7 @@ func (m *HandlerMap) Put(key string, value ResponseHandler) {
 				break // No more waiters blocked.
 			}
 			w := next.Value.(waiter)
+			waiters.Remove(next)
 			close(w.ready)
 		}
 		delete(m.waitersMap, key)

--- a/client/handler_map.go
+++ b/client/handler_map.go
@@ -11,7 +11,7 @@ import (
 type HandlerMap struct {
 	mu         sync.Mutex
 	innerMap   map[string]ResponseHandler
-	waitersMap map[string]list.List
+	waitersMap map[string]*list.List
 }
 
 type waiter struct {
@@ -21,7 +21,7 @@ type waiter struct {
 func NewHandlerMap() *HandlerMap {
 	return &HandlerMap{sync.Mutex{},
 		make(map[string]ResponseHandler, 100),
-		make(map[string]list.List, 100),
+		make(map[string]*list.List, 100),
 	}
 }
 
@@ -71,7 +71,7 @@ func (m *HandlerMap) Get(key string, timeoutMs int) (value ResponseHandler, ok b
 
 			waiters, wok := m.waitersMap[key]
 			if !wok {
-				waiters = list.List{}
+				waiters = &list.List{}
 				m.waitersMap[key] = waiters
 			}
 			ready := make(chan struct{})

--- a/client/handler_map_test.go
+++ b/client/handler_map_test.go
@@ -1,0 +1,87 @@
+package client
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+	"time"
+)
+
+const (
+	TEST_KEY = "test_key"
+)
+
+func getMsSince(startTime time.Time) int {
+	return int(time.Now().Sub(startTime).Nanoseconds() / 1e6)
+}
+
+func TestHandlerMapEarlyStoreRetrieve(t *testing.T) {
+
+	handler_map := NewHandlerMap()
+	var handler ResponseHandler = func(*Response) {
+		fmt.Printf("test: I got a response \n")
+	}
+	handler_map.Put(TEST_KEY, handler)
+	myHandler, ok := handler_map.Get(TEST_KEY, 20)
+	if !ok {
+		t.Error("Failed to get test key")
+	}
+	myHandler(nil)
+
+}
+
+func TestHandlerMapDelayedPutRetrieve(t *testing.T) {
+
+	handler_map := NewHandlerMap()
+	startTime := time.Now()
+
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+
+		// at this point the Get would be waiting for the response.
+		counts, waiters := handler_map.GetCounts()
+		assert.Equal(t, 0, counts, "Map Elements")
+		assert.Equal(t, 1, waiters, "Waiter groups")
+
+		var handler ResponseHandler = func(*Response) {
+			fmt.Printf("test: I got a response at time %d ms after start\n", getMsSince(startTime))
+		}
+		handler_map.Put(TEST_KEY, handler)
+	}()
+
+	fmt.Printf("test: Started waiting for key at %d ms after start\n", getMsSince(startTime))
+	myHandler, ok := handler_map.Get(TEST_KEY, 20)
+	if !ok {
+		t.Error("Failed to get test key")
+	}
+
+	myHandler(nil)
+}
+
+func TestHandlerMapTimeoutPutTooLate(t *testing.T) {
+
+	handler_map := NewHandlerMap()
+	startTime := time.Now()
+
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		var handler ResponseHandler = func(*Response) {
+			fmt.Printf("test: I got a response at time %d ms after start\n", getMsSince(startTime))
+		}
+		handler_map.Put(TEST_KEY, handler)
+	}()
+
+	fmt.Printf("test: Started waiting for key at %d ms after start\n", getMsSince(startTime))
+	_, ok := handler_map.Get(TEST_KEY, 20)
+	if ok {
+		t.Error("Should have timed out when getting the key")
+		return
+	} else {
+		// wait till producer has added the element
+		time.Sleep(20 * time.Millisecond)
+		counts, waiters := handler_map.GetCounts()
+		assert.Equal(t, 1, counts, "Map elements")
+		assert.Equal(t, 0, waiters, "Waiter groups")
+	}
+
+}

--- a/client/handler_map_test.go
+++ b/client/handler_map_test.go
@@ -67,10 +67,7 @@ func TestHandlerMapTimeoutPutTooLate(t *testing.T) {
 
 	go func() {
 		time.Sleep(2 * timeoutMs * time.Millisecond)
-		var handler ResponseHandler = func(*Response) {
-			t.Logf("test: got a response at time %d ms after start\n", getMsSince(startTime))
-		}
-		handler_map.Put(testKey, handler)
+		handler_map.Put(testKey, func(*Response) {})
 	}()
 
 	t.Logf("test: started waiting for key at %d ms after start\n", getMsSince(startTime))

--- a/client/handler_map_test.go
+++ b/client/handler_map_test.go
@@ -23,7 +23,7 @@ func TestHandlerMapEarlyStoreRetrieve(t *testing.T) {
 		t.Logf("test: got a response \n")
 	}
 	handler_map.Put(testKey, handler)
-	myHandler, ok := handler_map.Get(testKey, 20)
+	myHandler, ok := handler_map.Get(testKey, timeoutMs)
 	if !ok {
 		t.Error("Failed to get test key")
 	}
@@ -37,7 +37,7 @@ func TestHandlerMapDelayedPutRetrieve(t *testing.T) {
 	startTime := time.Now()
 
 	go func() {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(timeoutMs / 2 * time.Millisecond)
 
 		// at this point the Get would be waiting for the response.
 		counts, waiters := handler_map.GetCounts()
@@ -51,8 +51,7 @@ func TestHandlerMapDelayedPutRetrieve(t *testing.T) {
 	}()
 
 	t.Logf("test: started waiting for key at %d ms after start\n", getMsSince(startTime))
-	t.Logf("test: started waiting for key at %d ms after start\n", getMsSince(startTime))
-	myHandler, ok := handler_map.Get(testKey, 20)
+	myHandler, ok := handler_map.Get(testKey, timeoutMs)
 	if !ok {
 		t.Error("Failed to get test key")
 	}

--- a/client/handler_map_test.go
+++ b/client/handler_map_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	testKey   = "test_key"
-	timeoutMs = 100
+	testKey        = "test_key"
+	timeoutMs      = 200
+	marginErrorPct = 10
 )
 
 func getMsSince(startTime time.Time) int {
@@ -35,9 +36,10 @@ func TestHandlerMapDelayedPutRetrieve(t *testing.T) {
 
 	handler_map := NewHandlerMap()
 	startTime := time.Now()
+	expectedResponseMs := timeoutMs / 2
 
 	go func() {
-		time.Sleep(timeoutMs / 2 * time.Millisecond)
+		time.Sleep(time.Duration(expectedResponseMs) * time.Millisecond)
 
 		// at this point the Get would be waiting for the response.
 		counts, waiters := handler_map.GetCounts()
@@ -54,9 +56,16 @@ func TestHandlerMapDelayedPutRetrieve(t *testing.T) {
 	myHandler, ok := handler_map.Get(testKey, timeoutMs)
 	if !ok {
 		t.Error("Failed to get test key")
+	} else {
+		myHandler(nil)
+		actualResponseMs := getMsSince(startTime)
+		var comp assert.Comparison = func() (success bool) {
+			return math.Abs(float64(actualResponseMs-expectedResponseMs))/float64(expectedResponseMs) < float64(marginErrorPct)/100
+		}
+		assert.Condition(t, comp, "Response did not arrive within %d%% margin, expected time %d ms", marginErrorPct, expectedResponseMs)
+
 	}
 
-	myHandler(nil)
 }
 
 func TestHandlerMapTimeoutPutTooLate(t *testing.T) {
@@ -78,9 +87,9 @@ func TestHandlerMapTimeoutPutTooLate(t *testing.T) {
 		actualTimeoutMs := getMsSince(startTime)
 		t.Logf("test: timed out waiting for key at %d ms after start\n", actualTimeoutMs)
 		var comp assert.Comparison = func() (success bool) {
-			return math.Abs(float64(actualTimeoutMs-timeoutMs))/timeoutMs < 0.1
+			return math.Abs(float64(actualTimeoutMs-timeoutMs))/timeoutMs < float64(marginErrorPct)/100
 		}
-		assert.Condition(t, comp, "Timeout did not occur within 10%% margin, expected timeout ms: %d", timeoutMs)
+		assert.Condition(t, comp, "Timeout did not occur within %d%% margin, expected timeout ms: %d", marginErrorPct, timeoutMs)
 		// wait till producer has added the element
 		time.Sleep(3 * timeoutMs * time.Millisecond)
 		counts, waiters := handler_map.GetCounts()

--- a/client/handler_map_test.go
+++ b/client/handler_map_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	TestKey   = "test_key"
-	TimeoutMs = 100
+	testKey   = "test_key"
+	timeoutMs = 100
 )
 
 func getMsSince(startTime time.Time) int {
@@ -22,8 +22,8 @@ func TestHandlerMapEarlyStoreRetrieve(t *testing.T) {
 	var handler ResponseHandler = func(*Response) {
 		t.Logf("test: got a response \n")
 	}
-	handler_map.Put(TestKey, handler)
-	myHandler, ok := handler_map.Get(TestKey, 20)
+	handler_map.Put(testKey, handler)
+	myHandler, ok := handler_map.Get(testKey, 20)
 	if !ok {
 		t.Error("Failed to get test key")
 	}
@@ -47,12 +47,12 @@ func TestHandlerMapDelayedPutRetrieve(t *testing.T) {
 		var handler ResponseHandler = func(*Response) {
 			t.Logf("test: got a response at time %d ms after start\n", getMsSince(startTime))
 		}
-		handler_map.Put(TestKey, handler)
+		handler_map.Put(testKey, handler)
 	}()
 
 	t.Logf("test: started waiting for key at %d ms after start\n", getMsSince(startTime))
 	t.Logf("test: started waiting for key at %d ms after start\n", getMsSince(startTime))
-	myHandler, ok := handler_map.Get(TestKey, 20)
+	myHandler, ok := handler_map.Get(testKey, 20)
 	if !ok {
 		t.Error("Failed to get test key")
 	}
@@ -66,15 +66,15 @@ func TestHandlerMapTimeoutPutTooLate(t *testing.T) {
 	startTime := time.Now()
 
 	go func() {
-		time.Sleep(2 * TimeoutMs * time.Millisecond)
+		time.Sleep(2 * timeoutMs * time.Millisecond)
 		var handler ResponseHandler = func(*Response) {
 			t.Logf("test: got a response at time %d ms after start\n", getMsSince(startTime))
 		}
-		handler_map.Put(TestKey, handler)
+		handler_map.Put(testKey, handler)
 	}()
 
 	t.Logf("test: started waiting for key at %d ms after start\n", getMsSince(startTime))
-	_, ok := handler_map.Get(TestKey, TimeoutMs)
+	_, ok := handler_map.Get(testKey, timeoutMs)
 	if ok {
 		t.Error("Should have timed out when getting the key")
 		return
@@ -82,11 +82,11 @@ func TestHandlerMapTimeoutPutTooLate(t *testing.T) {
 		actualTimeoutMs := getMsSince(startTime)
 		t.Logf("test: timed out waiting for key at %d ms after start\n", actualTimeoutMs)
 		var comp assert.Comparison = func() (success bool) {
-			return math.Abs(float64(actualTimeoutMs-TimeoutMs))/TimeoutMs < 0.1
+			return math.Abs(float64(actualTimeoutMs-timeoutMs))/timeoutMs < 0.1
 		}
-		assert.Condition(t, comp, "Timeout did not occur within 10%% margin, expected timeout ms: %d", TimeoutMs)
+		assert.Condition(t, comp, "Timeout did not occur within 10%% margin, expected timeout ms: %d", timeoutMs)
 		// wait till producer has added the element
-		time.Sleep(3 * TimeoutMs * time.Millisecond)
+		time.Sleep(3 * timeoutMs * time.Millisecond)
 		counts, waiters := handler_map.GetCounts()
 		assert.Equal(t, 1, counts, "Map elements")
 		assert.Equal(t, 0, waiters, "Waiter groups")

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,8 @@ require (
 	github.com/spf13/pflag v1.0.1
 	github.com/stretchr/testify v1.3.0
 	github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d
+	golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
+	golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce // indirect
 	gopkg.in/robfig/cron.v2 v2.0.0-20150107220207-be2e0b0deed5


### PR DESCRIPTION
The job handler may not appear in the `client.handlers` in time before gearman responds with an update. This change adds a fine-grained polling for the handler to appear before giving up. 